### PR TITLE
Use file.path

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ module.exports = function(opts) {
                 var newFile = new gutil.File({
                     cwd: file.cwd,
                     base: file.base,
+                    path: file.path,
                     contents: new Buffer(src)
                 });
 


### PR DESCRIPTION
This was breaking my build process with a `No path specified! Can not get relative.` error
