### PR TITLE
Add support for browserify-shim

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var es = require('event-stream');
 var gutil = require('gulp-util');
 var browserify = require('browserify');
+var shim = require('browserify-shim');
 var path = require('path');
 var fs = require('fs');
 var isStream = gutil.isStream;
@@ -19,6 +20,7 @@ module.exports = function(opts) {
     var bundler, chunk = '';
     var itsABuffer = false;
     var itsAStream = false;
+    var lib;
 
     function bufferContents(file) {
     	buffer.push(file);
@@ -53,7 +55,16 @@ module.exports = function(opts) {
                 delete opts.noParse;
             }
 
-            bundler = browserify(ctrOpts);
+            if(opts.shim) {
+                for(lib in opts.shim) {
+                    opts.shim[lib].path = path.resolve(opts.shim[lib].path);
+                }
+                bundler = shim(browserify(), opts.shim);
+                bundler.require(file.path, { entry: true });
+            } else {
+                bundler = browserify(ctrOpts);
+            }
+
             bundler.on('error', function(err) {
                 error(err);
             })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "browserify": "~3.14.0",
     "event-stream": "*",
     "gulp-util": "~2.2.0",
-    "gulp-concat": "~2.1.4"
+    "gulp-concat": "~2.1.4",
+    "browserify-shim": "~2.0.10"
   },
   "main": "index.js",
   "engines": {

--- a/test/main.js
+++ b/test/main.js
@@ -34,7 +34,7 @@ describe('gulp-browserify', function() {
     expect(outputFile.base).to.be.a('string', 'file.base is not a string');
     expect(outputFile.path).to.be.a('string', 'file.path is not a string');
   })
-	
+
 	it('should bundle modules', function(done) {
 		var b = browserify();
 		var chunk = '';
@@ -67,4 +67,35 @@ describe('gulp-browserify', function() {
 			}))
 	})
 })
+
+describe('gulp-browserify shim', function() {
+	var testFile = path.join(__dirname, './shim/shim.js');
+	var shimFile = path.join(__dirname, './shim/bar.js');
+  var outputFile;
+
+	beforeEach(function(done) {
+    vfile = null;
+		gulp.src(testFile)
+			.pipe(gulpB({
+				shim: {
+					bar: {
+						path: shimFile,
+						exports: 'bar'
+					}
+				}
+			}))
+			.on('postbundle', function(data) {
+				postdata = data;
+			})
+			.pipe(es.map(function(file){
+				outputFile = file;
+				done();
+			}))
+	});
+	it('should be able to bundle all defined modules in to one bundle', function(done) {
+		expect(outputFile.contents.toString()).to.contain('window.bar = \'foobar\'');
+		expect(outputFile.contents.toString()).to.contain('console.log(\'foo\');');
+		done();
+	});
+});
 

--- a/test/shim/bar.js
+++ b/test/shim/bar.js
@@ -1,0 +1,3 @@
+(function(window) {
+  window.bar = 'foobar';
+})(window);

--- a/test/shim/shim.js
+++ b/test/shim/shim.js
@@ -1,0 +1,2 @@
+console.log('foo');
+require('bar');


### PR DESCRIPTION
Make CommonJS-Incompatible Files Browserifyable. Would be really handy for requiring client libraries installed with [Bower](http://bower.io/). I was going to write my own Gulp plugin for this, but I realized that it would be too similar to yours :)
