### PR TITLE
Handle error of browserify's bundle callback properly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,8 @@ module.exports = function(opts) {
             var onBundleComplete = function(self, err, src) {
                 if(err) {
                     error(err);
+                    self.emit('error', err);
+                    return;
                 }
 
                 var newFile = new gutil.File({

--- a/test/error/index.js
+++ b/test/error/index.js
@@ -1,0 +1,1 @@
+require('./non-existent-module');

--- a/test/main.js
+++ b/test/main.js
@@ -99,3 +99,13 @@ describe('gulp-browserify shim', function() {
 	});
 });
 
+describe('gulp-browserify non stream error', function () {
+	var testFile = path.join(__dirname, './error/index.js');
+
+	it('emits error if browserify calls callback with error', function (done) {
+		gulp.src(testFile, { read: false })
+			.pipe(gulpB())
+			.on('error', function () { done(); })
+			.on('postbundle', function () { throw new Error('No error was emitted.') });
+	});
+});


### PR DESCRIPTION
`err` to `onBundleComplete` was not properly handled and caused the following error.

```
Uncaught TypeError: First argument needs to be a number, array or string.
  at new Buffer (buffer.js:188:15)
  at onBundleComplete (/Users/s-kagawa/work/js/gulp-browserify/index.js:90:31)
  at Stream.<anonymous> (/Users/s-kagawa/work/js/gulp-browserify/index.js:108:21)
  at Stream.<anonymous> (/Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/index.js:232:22)
  at Stream.<anonymous> (/Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/index.js:232:22)
  at Stream.EventEmitter.emit (events.js:117:20)
  at Stream.EventEmitter.emit (events.js:117:20)
  at Stream.EventEmitter.emit (events.js:117:20)
  at /Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/node_modules/module-deps/index.js:91:36
  at /Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/index.js:570:20
  at /Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/node_modules/browser-resolve/index.js:183:24
  at /Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:36:22
  at load (/Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:54:43)
  at /Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:60:22
  at /Users/s-kagawa/work/js/gulp-browserify/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:16:47
  at Object.oncomplete (fs.js:107:15)
```

Browserify emits `error` event when it handles stream entries. However, it gives an error to `bundle()`'s callback function when it handles non-stream entries.
