### PR TITLE
Feature: pass 'resolve' option to browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Array of extensions that you want to skip in `require()` calls in addition to `.
 
 With `{ extensions: ['.coffee'] }`, you can do `require('app')`. Instead, you have to do `require('app.coffee')`.
 
+#### resolve
+
+Type: `Function`
+
+Custom module name resolution function. From [node-browserify](https://github.com/substack/node-browserify#var-b--browserifyfiles-or-opts) documentation:
+> You can give browserify a custom `opts.resolve()` function or by default it uses
+[`browser-resolve`](https://npmjs.org/package/browser-resolve).
+
+Obviously, this function must implement the same API as [browser-resolve](https://npmjs.org/package/browser-resolve).
+
 #### Other Options
 
 Any other options you provide will be passed through to browserify. This is useful for setting things like `standalone` or `ignoreGlobals`.

--- a/index.js
+++ b/index.js
@@ -29,15 +29,12 @@ module.exports = function(opts, data) {
   var buffer = [];
   var doneCount = 0;
 
-  if(opts.noParse) {
-      data.noParse = opts.noParse;
-      delete opts.noParse;
-  }
-
-  if(opts.extensions) {
-      data.extensions = opts.extensions;
-      delete opts.extensions;
-  }
+  ['noParse', 'extensions', 'resolve'].forEach(function(opt) {
+    if(opts[opt]) {
+      data[opt] = opts[opt];
+      delete opts[opt];
+    }
+  });
 
   function bundleBrowserify() {
     if (buffer.length === 0) return this.emit('end');

--- a/test/fixtures/custom_resolved.js
+++ b/test/fixtures/custom_resolved.js
@@ -1,0 +1,1 @@
+module.exports = 'resolved content';

--- a/test/main.js
+++ b/test/main.js
@@ -137,6 +137,23 @@ describe('gulp-browserify', function() {
     }).end(fakeFile);
   });
 
+  it('should use custom resolve function', function(done) {
+    // Use new Buffer instead of normal.js contents because normal.js
+    // requires "chai", and if this test fails (resolve function not used)
+    // all the chai will be printed to stdout (when .to.match() fails),
+    // that's annoying, trust me. And new fixture file for this is overkill.
+    var fakeFile = createFakeFile('fake.js', new Buffer('require("fake");'));
+    var opts = {
+      resolve: function(pkg, opts, cb) {
+        cb(null, path.resolve('./test/fixtures/custom_resolved.js'));
+      }
+    };
+    gulpB(opts).once('data', function(bundled) {
+      expect(bundled.contents.toString()).to.match(/resolved content/);
+      done();
+    }).end(fakeFile);
+  });
+
   it('should allow external with buffer', function(done) {
     var fakeFile = createFakeFile('normal.js', fs.readFileSync('test/fixtures/normal.js'));
     var files = [];


### PR DESCRIPTION
Pass `resolve` option value along with `noParse` and `extensions`.
This allows to specify custom module resolution function.
See: http://git.io/VuxXdg (node-browserify readme).

Add test to: `test/main.js`.
Test uses fixture: `test/fixtures/custom_resolved.js`.

Document this feature in `README.md`.

Btw, thanks for this awesome package, @deepak1556!
