### PR TITLE
Fix for '**' patterns in globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function(opts, data) {
       data.entries = arrayStream([file.contents]);
     }
 
-    data.basedir = file.base;
+    data.basedir = path.dirname(file.path);
 
     var bundler = browserify(data);
 


### PR DESCRIPTION
Browserify task fails for entry-points, described by globs with `**` pattern.
Example:

```
gulp.task('scripts', ['clean.scripts'], function () {
    return gulp
        .src('./app/scripts/pages/**/*.js')
        .pipe(browserify())
        .pipe(gulp.dest('./dist/js'));
});
```
