### PR TITLE
Include file name and line number in error message for syntax errors

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -290,12 +290,30 @@ describe('gulp-browserify', function() {
     }).end(fakeFile);
   });
 
-  it('should emit error when bundle throws error', function(done) {
+  it('should emit an error when bundle throws a standard error', function(done) {
+    var fakeFile = createFakeFile('not_found.js', new Buffer('require("--non-existent");'));
+    gulpB().once('error', function (err) {
+      expect(err).to.exist;
+      expect(err).to.be.instanceof(gutil.PluginError);
+      expect(err.message).to.include('module "--non-existent" not found');
+      expect(err.stack).to.exist;
+      expect(err.plugin).to.eq('gulp-browserify');
+      expect(err.name).to.eq('Error');
+      done();
+    }).end(fakeFile);
+  });
+
+  it('should emit an error with file name and line number when bundle throws a syntax error', function(done) {
     var fakeFile = createFakeFile('trans_error.coffee', null);
     var opts = { transform: ['coffeeify'], extensions: ['.coffee'] };
     gulpB(opts).once('error', function (err) {
       expect(err).to.exist;
       expect(err).to.be.instanceof(gutil.PluginError);
+      expect(err.message).to.include('test/fixtures/trans_error.coffee:2');
+      expect(err.message).to.include('ParseError: unexpected ');
+      expect(err.stack).to.exist;
+      expect(err.plugin).to.eq('gulp-browserify');
+      expect(err.name).to.eq('SyntaxError');
       done();
     }).end(fakeFile);
   });


### PR DESCRIPTION
As @nickdima pointed out at #37, it would be nice to show file name and line number of syntax error.

Browserify and some transforms like coffeeify emits ParseError defined in [node-syntax-error](https://github.com/substack/node-syntax-error). It has file name and line number in `annotated` property. So let's use it if available.
