### PR TITLE
shim breaks when invoked multiple times by gulp (close #62)

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function wrapWithPluginError(originalError){
 }
 
 module.exports = function(opts, data){
-  opts = opts || {};
+  opts = JSON.parse(JSON.stringify(opts || {})); // make deep copy, we are going to modify opts eventually
   data = data || {};
 
   ['noParse', 'extensions', 'resolve'].forEach(function(opt){


### PR DESCRIPTION
Shim config gets mutated when shim transformation is called.
Multiple invocations cause single file to be wrapped multiple times,
which breaks the wrapping functionality and leads to very cryptic javascript errors.

This problem gets exposed for example using shims together with file watching.
https://github.com/FrenkyNet/gulp-browserify-bug-62/blob/master/gulpfile.js
