### PR TITLE
Removed deprecated `gulp-util` dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var through = require('through2');
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var browserify = require('browserify');
 var shim = require('browserify-shim');
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   ],
   "dependencies": {
     "browserify": "3.x",
-    "gulp-util": "~2.2.5",
     "browserify-shim": "~2.0.10",
+    "plugin-error": "^1.0.1",
     "readable-stream": "~1.1.10",
-    "through2": "~0.4.0"
+    "through2": "~0.4.0",
+    "vinyl": "^2.1.0"
   },
   "main": "index.js",
   "engines": {
@@ -25,9 +26,9 @@
     "test": "./node_modules/.bin/mocha"
   },
   "devDependencies": {
-    "mocha": "~1.17.1",
     "chai": "~1.9.0",
-    "coffeeify": "~0.6.0"
+    "coffeeify": "~0.6.0",
+    "mocha": "~1.17.1"
   },
   "keywords": [
     "gulpplugin",

--- a/test/fixtures/normal2.js
+++ b/test/fixtures/normal2.js
@@ -1,1 +1,0 @@
-var gutil = require('gulp-util');

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
-var gutil = require('gulp-util');
+var File = require('vinyl');
+var PluginError = require('plugin-error');
 var coffeeify = require('coffeeify');
 var expect = require('chai').expect;
 var vm = require('vm')
@@ -10,7 +11,7 @@ var gulpB = require('../');
 var prepare = require('./prepare');
 
 function createFakeFile(filename, contents) {
-  return new gutil.File({
+  return new File({
     cwd: process.cwd(),
     base: path.join(__dirname, 'fixtures'),
     path: path.join(__dirname, 'fixtures', filename),
@@ -295,7 +296,7 @@ describe('gulp-browserify', function() {
     var fakeFile = createFakeFile('not_found.js', new Buffer('require("--non-existent");'));
     gulpB().once('error', function (err) {
       expect(err).to.exist;
-      expect(err).to.be.instanceof(gutil.PluginError);
+      expect(err).to.be.instanceof(PluginError);
       expect(err.message).to.include('module "--non-existent" not found');
       expect(err.stack).to.exist;
       expect(err.plugin).to.eq('gulp-browserify');
@@ -309,7 +310,7 @@ describe('gulp-browserify', function() {
     var opts = { transform: ['coffeeify'], extensions: ['.coffee'] };
     gulpB(opts).once('error', function (err) {
       expect(err).to.exist;
-      expect(err).to.be.instanceof(gutil.PluginError);
+      expect(err).to.be.instanceof(PluginError);
       expect(err.message).to.include('test/fixtures/trans_error.coffee:2');
       expect(err.message).to.include('ParseError: unexpected ');
       expect(err.stack).to.exist;
@@ -329,7 +330,7 @@ describe('gulp-browserify', function() {
     var opts = { transform: [stringErrorTransform], extensions: ['.coffee'] };
     gulpB(opts).once('error', function (err) {
       expect(err).to.exist;
-      expect(err).to.be.instanceof(gutil.PluginError);
+      expect(err).to.be.instanceof(PluginError);
       expect(err.message).to.eq('string error!');
       expect(err.plugin).to.eq('gulp-browserify');
       expect(err.stack).to.exist;


### PR DESCRIPTION
Removed `gulp-util` in favor of the `vinyl` and `plugin-error` packages.